### PR TITLE
Update ips.md

### DIFF
--- a/ips.md
+++ b/ips.md
@@ -377,6 +377,7 @@ If your server uses a **Red Hat Enterprise Linux (RHEL)** license provided by So
 |Singapore (SNG01)|TOK02 and SYD01|
 |Seattle (SEA01)|SJC03 and DAL06|
 |Sydney (SYD01, SYD04)|SYD01|
+|Tokyo (TOK02, TOK04, TOK05)|TOK02 and SYD01|
 |Toronto (TOR01)|TOR01|
 |Washington DC (WDC01, WDC04, WDC06, WDC07)|MON01|
 |Any DC Not Listed Above|DAL09|


### PR DESCRIPTION
Those updates was already approved, but changes had been reverted back recently (devices in TOK region need access to TOK02 and SYD01 for Red Hat Enterprise Linux Subscription and license).